### PR TITLE
Set content-type header on exchange_for_access_token

### DIFF
--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -109,7 +109,8 @@ class OAuth2AuthExchangeRequest(object):
         data = self._data_for_exchange(code, username, password, scope=scope, user_id=user_id)
         http_object = Http(disable_ssl_certificate_validation=True)
         url = self.api.access_token_url
-        response, content = http_object.request(url, method="POST", body=data)
+        response, content = http_object.request(url, method="POST", body=data,
+                                                headers={'content-type': 'application/x-www-form-urlencoded'})
         parsed_content = simplejson.loads(content.decode())
         if int(response['status']) != 200:
             raise OAuth2AuthExchangeError(parsed_content.get("error_message", ""))


### PR DESCRIPTION
This fixes a "Need to provide client_id" when trying to get an access_token
